### PR TITLE
Common serialization

### DIFF
--- a/IzzyParser/Izzy.swift
+++ b/IzzyParser/Izzy.swift
@@ -3,7 +3,7 @@ import Foundation
 public class Izzy {
     public var deserializer: Deserializer = IzzyDeserializer()
     public var serializer: Serializer = IzzySerializer()
-
+    
     public init() {}
     
     /**
@@ -54,13 +54,13 @@ public class Izzy {
     // MARK: - Serialization
     
     /**
-     Method for serializing single resource.
+     Method for serializing single resource. For internal usage only.
      
      - parameter resource: Resource object
      - returns: serialized resource dictionary
      
      */
-    public func serialize(resource: Resource) -> [String: Any] {
+    func serialize(resource: Resource) -> [String: Any] {
         return serializer.serialize(resource: resource)
     }
     
@@ -84,10 +84,10 @@ public class Izzy {
      - returns: dictionary with serialized resource
      
      */
-    public func serializeCustom(resource: Resource, attributeKey: String, attributeValue: Any) -> [String: Any] {
+    public func serializeCustom(resource: Resource, attributeKey: String, attributeValue: Any?) -> [String: Any] {
         return serializer.serialize(resource, attributeKey: attributeKey, attributeValue: attributeValue)
     }
-
+    
     /**
      Method for serializing single resource object with custom relationship dictionary.
      

--- a/IzzyParser/ResourceObjects/Resource.swift
+++ b/IzzyParser/ResourceObjects/Resource.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc open class Resource: NSObject {
-
+    
     @objc public var id: String
     @objc public var links: Links?
     @objc public var meta: Meta?
@@ -13,13 +13,28 @@ import Foundation
     open class var typesForKeys: [String: CustomObject.Type] {
         return [:]
     }
-
+    
     open class var customKeys: [String: String] {
         return [:]
     }
-
+    
     public required init(id: String) {
         self.id = id
         super.init()
+    }
+}
+
+@objc protocol ResourceSerialization {
+    
+    /// Serializes the resource. By default calls `Izzy().serialize(resource: self)`.
+    /// - Can be overridden to serialize complex objects with multiple non-objc optional properties such as `Int?`, `Double?`, etc.
+    /// - Returns: Serialized object.
+    func serialized() -> [String: Any]
+}
+
+extension Resource: ResourceSerialization {
+    
+    @objc open func serialized() -> [String: Any] {
+        return Izzy().serialize(resource: self)
     }
 }

--- a/IzzyParser/Serialization/IzzyBuilder.swift
+++ b/IzzyParser/Serialization/IzzyBuilder.swift
@@ -1,0 +1,41 @@
+import Foundation
+import ObjectiveC.runtime
+
+public class IzzyBuilder {
+    
+    private let singleSerializer = SingleResourceSerializer()
+    
+    private var dictionary: SingleResourceJSON?
+    private var attributes = [String: Any]()
+    private var relationships = [String: Any]()
+    
+    public init(resource: Resource) {
+        dictionary = singleSerializer.parse(resource: resource)
+        attributes = dictionary?.attributes ?? [:]
+        relationships = dictionary?.relationships ?? [:]
+    }
+    
+    public func attribute(_ name: String, value: Any?) -> Self {
+        if let value = value {
+            attributes.updateValue(value, forKey: name)
+        }
+        return self
+    }
+    
+    public func relationship(_ name: String, value: Any?) -> Self {
+        if let value = value {
+            relationships.updateValue(value, forKey: name)
+        }
+        return self
+    }
+    
+    public func serialize() -> [String: Any] {
+        let resourceJson = SingleResourceJSON(data: dictionary?.data ?? [:],
+                                              attributes: attributes,
+                                              relationships: relationships)
+        var document = [String: Any]()
+        document.data = resourceJson.toDataDictionary()
+        
+        return document
+    }
+}

--- a/README.md
+++ b/README.md
@@ -265,6 +265,36 @@ Output:
  */
 ```
 
+#### Serializing objects with multiple optional non-objc properties
+
+```swift
+@objcMembers public final class SalaryDTO: Resource {
+    
+    public override class var type: String {
+        return "salary"
+    }
+
+    public var salary: Int?
+    public var salaryMin: Int?
+    public var salaryMax: Int?
+
+    public required init(id: String) {
+        super.init(id: id)
+    }
+    
+    public func serialized() -> [String : Any] {
+        return IzzyBuilder(resource: self)
+            .attribute("salary", value: salary)
+            .attribute("salaryMin", value: salaryMin)
+            .attribute("salaryMax", value: salaryMax)
+            .serialize()
+    }
+}
+
+// ...
+
+print(SalaryDTO(id: UUID().uuidString).serialized())
+```
 
 ### Deserializing
 


### PR DESCRIPTION
Added common Resource serialization method to unify serializing simple & complex objects. Also restricted external access to the `Izzy().serialize()` method to prevent invalid serialization possibility.